### PR TITLE
[Fix] 프로덕션에서 api 요청시 mixed content 오류 발생하는 이슈 수정

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,12 @@ import { Head, Html, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html lang="ko">
-      <Head title="Coply" />
+      <Head title="Coply">
+        <meta
+          httpEquiv="Content-Security-Policy"
+          content="upgrade-insecure-requests"
+        />
+      </Head>
       <body>
         <Main />
         <NextScript />


### PR DESCRIPTION
## 원인
프로덕선에서 https -> http 요청 시 mixed-content 오류 발생

## 해결
https 로 리소스 불러오는 메타태그 추가 
- 받아오는 리소스가 https 가 아니면 문제가 있다고 해서 api 를 https 로 수정하는 방향으로 논의 중