### PR TITLE
[리팩토링] 로그인 페이지 컴포넌트에서 컨텐츠를 컴포넌트로 분리

### DIFF
--- a/src/containers/pages/signin/hooks/index.ts
+++ b/src/containers/pages/signin/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-google-login';

--- a/src/containers/pages/signin/hooks/use-google-login.ts
+++ b/src/containers/pages/signin/hooks/use-google-login.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { signIn } from '@/apis/auth';
+import { SignInResponse } from '@/apis/models/auth';
+import { getGoogleAccessTokenFromPath, getGoogleOAuthUrl } from '../utils';
+
+interface UseGoogleLoginProps {
+  onSuccess?: (res: SignInResponse) => void;
+}
+
+export const useGoogleLogin = ({ onSuccess }: UseGoogleLoginProps) => {
+  const { mutate, isPending } = useMutation({
+    mutationFn: signIn,
+    onSuccess,
+  });
+
+  const onGoogleLogin = () => {
+    if (
+      !process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ||
+      !process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI
+    ) {
+      return;
+    }
+
+    const googleOAuthUrl = getGoogleOAuthUrl(
+      process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+      process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI,
+    );
+    window.location.href = googleOAuthUrl;
+  };
+
+  useEffect(() => {
+    const accessToken = getGoogleAccessTokenFromPath();
+    if (!accessToken) {
+      return;
+    }
+    mutate({ token: accessToken });
+  }, [mutate]);
+
+  return {
+    onGoogleLogin,
+    isLoading: isPending,
+  };
+};

--- a/src/containers/pages/signin/index.ts
+++ b/src/containers/pages/signin/index.ts
@@ -1,0 +1,1 @@
+export * from './signin.container';

--- a/src/containers/pages/signin/signin.container.tsx
+++ b/src/containers/pages/signin/signin.container.tsx
@@ -1,53 +1,19 @@
-import { useMutation } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
-import { signIn } from '@/apis/auth';
 import { GoogleButton } from '@/components/signin-page';
 import { setSession } from '@/utils/session';
+import { useGoogleLogin } from './hooks';
 
 export function SignInContainer() {
   const router = useRouter();
 
-  const signInMutation = useMutation({
-    mutationFn: signIn,
+  const { onGoogleLogin, isLoading } = useGoogleLogin({
     onSuccess: (res) => {
       setSession(res.accessToken);
       router.push('/');
     },
   });
-
-  useEffect(() => {
-    const parsedHash = new URLSearchParams(window.location.hash.substring(1));
-    const accessToken = parsedHash.get('access_token');
-    if (!accessToken) {
-      return;
-    }
-    signInMutation.mutate({ token: accessToken });
-  }, [signInMutation.mutate]);
-
-  const handleGoogleSignIn = () => {
-    if (
-      !process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ||
-      !process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI
-    ) {
-      return;
-    }
-
-    const url = new URL('https://accounts.google.com/o/oauth2/auth');
-    url.searchParams.set('client_id', process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID);
-    url.searchParams.set(
-      'redirect_uri',
-      process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI,
-    );
-    url.searchParams.set('response_type', 'token');
-    url.searchParams.set(
-      'scope',
-      'https://www.googleapis.com/auth/userinfo.email',
-    );
-    window.location.href = url.toString();
-  };
 
   return (
     <main className="my-[240px] flex flex-col items-center">
@@ -55,10 +21,7 @@ export function SignInContainer() {
       <Link className="mb-[52px] font-sans text-6xl text-gray-700" href="/">
         Coply
       </Link>
-      <GoogleButton
-        onClick={handleGoogleSignIn}
-        disabled={signInMutation.isPending}
-      />
+      <GoogleButton onClick={onGoogleLogin} disabled={isLoading} />
     </main>
   );
 }

--- a/src/containers/pages/signin/signin.container.tsx
+++ b/src/containers/pages/signin/signin.container.tsx
@@ -1,0 +1,64 @@
+import { useMutation } from '@tanstack/react-query';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { signIn } from '@/apis/auth';
+import { GoogleButton } from '@/components/signin-page';
+import { setSession } from '@/utils/session';
+
+export function SignInContainer() {
+  const router = useRouter();
+
+  const signInMutation = useMutation({
+    mutationFn: signIn,
+    onSuccess: (res) => {
+      setSession(res.accessToken);
+      router.push('/');
+    },
+  });
+
+  useEffect(() => {
+    const parsedHash = new URLSearchParams(window.location.hash.substring(1));
+    const accessToken = parsedHash.get('access_token');
+    if (!accessToken) {
+      return;
+    }
+    signInMutation.mutate({ token: accessToken });
+  }, [signInMutation.mutate]);
+
+  const handleGoogleSignIn = () => {
+    if (
+      !process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ||
+      !process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI
+    ) {
+      return;
+    }
+
+    const url = new URL('https://accounts.google.com/o/oauth2/auth');
+    url.searchParams.set('client_id', process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID);
+    url.searchParams.set(
+      'redirect_uri',
+      process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI,
+    );
+    url.searchParams.set('response_type', 'token');
+    url.searchParams.set(
+      'scope',
+      'https://www.googleapis.com/auth/userinfo.email',
+    );
+    window.location.href = url.toString();
+  };
+
+  return (
+    <main className="my-[240px] flex flex-col items-center">
+      <Image src="/flag.svg" width={120} height={120} alt="logo" />
+      <Link className="mb-[52px] font-sans text-6xl text-gray-700" href="/">
+        Coply
+      </Link>
+      <GoogleButton
+        onClick={handleGoogleSignIn}
+        disabled={signInMutation.isPending}
+      />
+    </main>
+  );
+}

--- a/src/containers/pages/signin/utils/google-login.util.ts
+++ b/src/containers/pages/signin/utils/google-login.util.ts
@@ -1,0 +1,19 @@
+export const getGoogleOAuthUrl = (clientId: string, redirectUri: string) => {
+  const url = new URL('https://accounts.google.com/o/oauth2/v2/auth');
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('response_type', 'token');
+  url.searchParams.set(
+    'scope',
+    'https://www.googleapis.com/auth/userinfo.email',
+  );
+
+  return url.toString();
+};
+
+export const getGoogleAccessTokenFromPath = () => {
+  const parsedHash = new URLSearchParams(window.location.hash.substring(1));
+  const accessToken = parsedHash.get('access_token');
+
+  return accessToken;
+};

--- a/src/containers/pages/signin/utils/index.ts
+++ b/src/containers/pages/signin/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './google-login.util';

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -1,71 +1,13 @@
-import { signIn } from '@/apis/auth';
-import { GoogleButton } from '@/components/signin-page';
-import { setSession } from '@/utils/session';
-import { useMutation } from '@tanstack/react-query';
 import Head from 'next/head';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { SignInContainer } from '@/containers/pages/signin';
 
 export default function SigninPage() {
-  const router = useRouter();
-
-  const signInMutation = useMutation({
-    mutationFn: signIn,
-    onSuccess: (res) => {
-      setSession(res.accessToken);
-      router.push('/');
-    },
-  });
-
-  useEffect(() => {
-    const parsedHash = new URLSearchParams(window.location.hash.substring(1));
-    const accessToken = parsedHash.get('access_token');
-    if (!accessToken) {
-      return;
-    }
-    signInMutation.mutate({ token: accessToken });
-  }, [signInMutation.mutate]);
-
-  const handleGoogleSignIn = () => {
-    if (
-      !process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ||
-      !process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI
-    ) {
-      return;
-    }
-
-    const url = new URL('https://accounts.google.com/o/oauth2/auth');
-    url.searchParams.set('client_id', process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID);
-    url.searchParams.set(
-      'redirect_uri',
-      process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI,
-    );
-    url.searchParams.set('response_type', 'token');
-    url.searchParams.set(
-      'scope',
-      'https://www.googleapis.com/auth/userinfo.email',
-    );
-    window.location.href = url.toString();
-  };
-
   return (
     <>
       <Head>
         <title>로그인 | Coply</title>
       </Head>
-
-      <main className="my-[240px] flex flex-col items-center">
-        <Image src="/flag.svg" width={120} height={120} alt="logo" />
-        <Link className="mb-[52px] font-sans text-6xl text-gray-700" href="/">
-          Coply
-        </Link>
-        <GoogleButton
-          onClick={handleGoogleSignIn}
-          disabled={signInMutation.isPending}
-        />
-      </main>
+      <SignInContainer />
     </>
   );
 }


### PR DESCRIPTION
# AS-IS

- 페이지 컴포넌트에서 페이지에 관련된 Jsx, 비즈니스 로직을 추가해서 작업하는데 페이지 컴포넌트에서만 사용할 커스텀 훅을 추가했을 때 파일 위치에 대한 고민이 있었음
- src/hooks 폴더는 도메인 상관없이 사용할 훅을 모아 놓는다고 정의해놨는데 페이지 컴포넌트에 대한 훅들이 섞이면 폴더의 의미가 희석된다고 생각했음
- src/hooks/page 폴더에 두는 것도 괜찮을것 같긴 한데 사용하는 컴포넌트 파일에서 떨어져있는 위치라 종속 관계를 잘 설명해주지 못하고, 파일 찾는 것도 어려울 수 있을 것 같음

# TO-BE

- src/containers/pages 폴더를 만들어 페이지에 들어갈 컨텐츠 컴포넌트를 관리
- 페이지 컴포넌트에서 사용하는 훅도 src/containers/pages/{page}/hooks 에서 관리
- components 는 그 하위에 두기엔 뎁스가 너무 깊어질 것 같아서 srcs/components 에서 관리하도록 함