### PR TITLE
[관리자페이지(영상)] 삭제 기능 추가

### DIFF
--- a/src/apis/admin.ts
+++ b/src/apis/admin.ts
@@ -20,3 +20,12 @@ export const getVideosForAdmin = async (
   const videos = getVideosResponseSchema.parse(data);
   return videos;
 };
+
+export const deleteVideoByIdForAdmin = async (
+  accessToken: string,
+  videoId: string,
+) => {
+  return axiosInstance.delete(`/admin/videos/${videoId}`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+};

--- a/src/components/admin/delete-video-dialog-content/delete-video-dialog-content.tsx
+++ b/src/components/admin/delete-video-dialog-content/delete-video-dialog-content.tsx
@@ -1,6 +1,10 @@
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Button } from '@/components/shared';
-import { DialogHeader, DialogFooter } from '@/components/ui/dialog';
+import {
+  DialogHeader,
+  DialogFooter,
+  DialogClose,
+} from '@/components/ui/dialog';
 
 interface DeleteVideoDialogContentProps {
   onDelete: () => void;
@@ -16,9 +20,9 @@ export function DeleteVideoDialogContent({
       </DialogHeader>
       정말 삭제하시겠습니까?
       <DialogFooter>
-        <DialogPrimitive.Close asChild>
+        <DialogClose asChild>
           <Button>취소</Button>
-        </DialogPrimitive.Close>
+        </DialogClose>
         <Button onClick={onDelete}>삭제</Button>
       </DialogFooter>
     </>

--- a/src/components/admin/delete-video-dialog-content/delete-video-dialog-content.tsx
+++ b/src/components/admin/delete-video-dialog-content/delete-video-dialog-content.tsx
@@ -2,7 +2,13 @@ import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { Button } from '@/components/shared';
 import { DialogHeader, DialogFooter } from '@/components/ui/dialog';
 
-export function DeleteVideoDialogContent() {
+interface DeleteVideoDialogContentProps {
+  onDelete: () => void;
+}
+
+export function DeleteVideoDialogContent({
+  onDelete,
+}: DeleteVideoDialogContentProps) {
   return (
     <>
       <DialogHeader>
@@ -13,7 +19,7 @@ export function DeleteVideoDialogContent() {
         <DialogPrimitive.Close asChild>
           <Button>취소</Button>
         </DialogPrimitive.Close>
-        <Button>저장</Button>
+        <Button onClick={onDelete}>삭제</Button>
       </DialogFooter>
     </>
   );

--- a/src/components/admin/dialog-trigger-wrapper/dialog-trigger-wrapper.tsx
+++ b/src/components/admin/dialog-trigger-wrapper/dialog-trigger-wrapper.tsx
@@ -1,7 +1,8 @@
 import { ReactNode } from 'react';
+import { DialogProps } from '@radix-ui/react-dialog';
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 
-interface DialogTriggerWrapperProps {
+export interface DialogTriggerWrapperProps extends DialogProps {
   trigger: ReactNode;
   dialogContent: ReactNode;
 }
@@ -9,9 +10,10 @@ interface DialogTriggerWrapperProps {
 export function DialogTriggerWrapper({
   trigger,
   dialogContent,
+  ...props
 }: DialogTriggerWrapperProps) {
   return (
-    <Dialog>
+    <Dialog {...props}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent>{dialogContent}</DialogContent>
     </Dialog>

--- a/src/containers/pages/admin/video/containers/delete-video-dialog-container/delete-video-dialog.container.tsx
+++ b/src/containers/pages/admin/video/containers/delete-video-dialog-container/delete-video-dialog.container.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { DeleteVideoDialogContent } from '@/components/admin/delete-video-dialog-content';
+import { DialogTriggerWrapper } from '@/components/admin/dialog-trigger-wrapper';
+import { Button } from '@/components/shared';
+
+interface DeleteVideoDialogContentProps {
+  onDelete: () => void;
+}
+
+export function DeleteVideoDialogContainer({
+  onDelete,
+}: DeleteVideoDialogContentProps) {
+  const [open, setOpen] = useState(false);
+
+  const handleDelete = () => {
+    onDelete();
+    setOpen(false);
+  };
+
+  return (
+    <DialogTriggerWrapper
+      key="remove"
+      open={open}
+      onOpenChange={setOpen}
+      trigger={<Button>X</Button>}
+      dialogContent={<DeleteVideoDialogContent onDelete={handleDelete} />}
+    />
+  );
+}

--- a/src/containers/pages/admin/video/containers/delete-video-dialog-container/index.ts
+++ b/src/containers/pages/admin/video/containers/delete-video-dialog-container/index.ts
@@ -1,0 +1,1 @@
+export * from './delete-video-dialog.container';

--- a/src/containers/pages/main/hooks/use-recommended-videos.ts
+++ b/src/containers/pages/main/hooks/use-recommended-videos.ts
@@ -5,26 +5,22 @@ import { getVideoById } from '@/apis/videos';
 import { recommendedSections } from '../models/main.model';
 
 export const useRecommendedVideos = () => {
-  const convertToObject = useCallback(
-    (results: UseQueryResult[]): Record<string, GetVideoResponse> => {
-      const videos = results
-        .map((result) => result.data)
-        .filter((data): data is GetVideoResponse => !!data);
-      return videos.reduce((acc, video) => {
-        return {
-          ...acc,
-          [video.id]: video,
-        };
-      }, {});
-    },
-    [],
-  );
+  const convertToObject = useCallback((results: UseQueryResult[]) => {
+    const videos = results
+      .map((result) => result.data)
+      .filter((data): data is GetVideoResponse => !!data)
+      .reduce<Map<string, GetVideoResponse>>((acc, video) => {
+        acc.set(video.id, video);
+        return acc;
+      }, new Map());
+    return videos;
+  }, []);
 
   const videoIds = recommendedSections.flatMap((section) => section.videoIds);
 
   const videoResults = useQueries<
     GetVideoResponse[],
-    Record<string, GetVideoResponse>
+    Map<string, GetVideoResponse>
   >({
     queries: videoIds.map((videoId) => ({
       queryKey: ['videos', { videoId }],

--- a/src/containers/pages/main/hooks/use-recommended-videos.ts
+++ b/src/containers/pages/main/hooks/use-recommended-videos.ts
@@ -25,6 +25,7 @@ export const useRecommendedVideos = () => {
     queries: videoIds.map((videoId) => ({
       queryKey: ['videos', { videoId }],
       queryFn: () => getVideoById(videoId),
+      retry: 0,
     })),
     combine: convertToObject,
   });

--- a/src/containers/pages/main/utils/convert-response.ts
+++ b/src/containers/pages/main/utils/convert-response.ts
@@ -3,15 +3,26 @@ import { VideoItem } from '@/components/shared/video-list';
 
 export const getVideoItems = (
   videoIds: string[],
-  videos: Record<string, GetVideoResponse>,
+  videos: Map<string, GetVideoResponse>,
 ): VideoItem[] => {
-  return videoIds.map((id) => {
-    const video = videos[id];
-    return {
+  if (!videos) {
+    return [];
+  }
+
+  const videoItems: VideoItem[] = [];
+
+  videoIds.forEach((id) => {
+    const video = videos.get(id);
+    if (!video) {
+      return;
+    }
+    videoItems.push({
       id: video.id,
       name: video.name,
       channelName: video.videoChannel.name,
       thumbnailUrl: video.thumbnailImageUrl,
-    };
+    });
   });
+
+  return videoItems;
 };


### PR DESCRIPTION
## 참고 자료
- radix dialog 비동기 닫기 https://www.radix-ui.com/primitives/docs/components/dialog#close-after-asynchronous-form-submission

## 트러블 슈팅
- 이슈: 관리자 페이지에서 영상 삭제 테스트 후 메인 페이지 접근 시 undefined 참조 오류 발생하면서 상태코드 500 응답됨

- 원인:
  - 메인에 보여줄 추천 영상 id를 프론트에서 관리하고, 데이터는 서버에서 불러와서 바인딩 하고 있음
  - 받아온 데이터는 id 를 키값으로 한 Record 타입으로 변환함
  - 프론트에서 하드코딩된 id 를 모두 순회하며 받아온 데이터를 조회하는데 Record 타입에 id 로 접근했을 때 조회한 데이터가 없는 경우 reference error 가 발생함

- 해결:
Record 타입 대신 Map 타입을 사용하고, 값이 있는 경우에만 변환해서 렌더링하도록 함
이외에도 키값으로 접근해서 데이터를 참조하려고 하는 경우에는 객체가 아닌 Map 타입을 사용해 개발 단계에서 체크하려고 함