### PR TITLE
[관리자페이지, 탐색페이지] 카테고리 단일에서 다중 선택으로 수정

### DIFF
--- a/src/apis/models/admin.ts
+++ b/src/apis/models/admin.ts
@@ -10,7 +10,7 @@ const getVideosForAdminRequestParamsSchema = z
 
 const updateVideoInfoByIdForAdminRequestParamsSchema = z
   .object({
-    category: z.enum(categories),
+    categories: z.array(z.enum(categories)),
     level: z.enum(levels),
   })
   .partial();
@@ -19,7 +19,7 @@ const addVideoForAdminRequestParamsSchema = z.object({
   videos: z
     .object({
       videoId: z.string(),
-      category: z.enum(categories),
+      categories: z.array(z.enum(categories)),
       level: z.enum(levels),
     })
     .array(),

--- a/src/apis/models/video.ts
+++ b/src/apis/models/video.ts
@@ -44,5 +44,5 @@ export type GetVideosRequestParams = z.infer<
 
 export type GetVideoResponse = z.infer<typeof videoSchema>;
 
-export type LevelUnion = (typeof levels)[number];
-export type CategoryUnion = (typeof categories)[number];
+export type Level = (typeof levels)[number];
+export type Category = (typeof categories)[number];

--- a/src/apis/models/video.ts
+++ b/src/apis/models/video.ts
@@ -31,7 +31,8 @@ export const getVideosRequestParamsSchema = z
     take: z.number(),
     page: z.number(),
     keyword: z.string(),
-    category: z.enum(categories),
+    // 실제 요청 형태: ?categories[]=FE&categories[]=BE
+    categories: z.array(z.enum(categories)),
     level: z.enum(levels),
   })
   .partial();

--- a/src/apis/models/video.ts
+++ b/src/apis/models/video.ts
@@ -10,7 +10,7 @@ export const videoSchema = z.object({
   thumbnailImageUrl: z.string(),
   duration: z.number(),
   level: z.enum(levels),
-  category: z.enum(categories),
+  categories: z.array(z.enum(categories)),
   uploadedAt: z.string(),
   videoChannel: z.object({
     id: z.number(),

--- a/src/components/admin/add-video-table/add-video-table.tsx
+++ b/src/components/admin/add-video-table/add-video-table.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 /* eslint-disable react/jsx-key */
-import { CategoryUnion, LevelUnion } from '@/apis/models/video';
+import { Category, Level } from '@/apis/models/video';
 import { TableCell, TableRow } from '@/components/ui/table';
 import {
   MANAGE_VIDEO_ITEM_MAX_COUNT,
@@ -19,12 +19,8 @@ interface AddVideoTableProps {
   items: ManageVideoItem[];
   onAdd: () => void;
   onChangeVideoId: (id: string, videoId: string) => void;
-  onChangeLevel: (id: string, level: LevelUnion) => void;
-  onCheckCategory: (
-    id: string,
-    category: CategoryUnion,
-    checked: boolean,
-  ) => void;
+  onChangeLevel: (id: string, level: Level) => void;
+  onCheckCategory: (id: string, category: Category, checked: boolean) => void;
   onRemove: (id: string) => void;
 }
 

--- a/src/components/admin/add-video-table/add-video-table.tsx
+++ b/src/components/admin/add-video-table/add-video-table.tsx
@@ -20,7 +20,11 @@ interface AddVideoTableProps {
   onAdd: () => void;
   onChangeVideoId: (id: string, videoId: string) => void;
   onCheckLevel: (id: string, level: LevelUnion, checked: boolean) => void;
-  onSelectCategory: (id: string, category: CategoryUnion) => void;
+  onCheckCategory: (
+    id: string,
+    category: CategoryUnion,
+    checked: boolean,
+  ) => void;
   onRemove: (id: string) => void;
 }
 
@@ -29,7 +33,7 @@ export function AddVideoTable({
   onAdd,
   onRemove,
   onChangeVideoId,
-  onSelectCategory,
+  onCheckCategory,
   onCheckLevel,
 }: AddVideoTableProps) {
   const showAddButton = items.length < MANAGE_VIDEO_ITEM_MAX_COUNT;
@@ -44,8 +48,10 @@ export function AddVideoTable({
         onBlur={(event) => onChangeVideoId(item.id, event.currentTarget.value)}
       />,
       <CategoryDropdown
-        category={item.category}
-        onChange={(category) => onSelectCategory(item.id, category)}
+        categories={item.categories}
+        onCheck={(checked, category) =>
+          onCheckCategory(item.id, category, checked)
+        }
       />,
       <LevelDropdown
         // levels={item.levels}

--- a/src/components/admin/add-video-table/add-video-table.tsx
+++ b/src/components/admin/add-video-table/add-video-table.tsx
@@ -19,7 +19,7 @@ interface AddVideoTableProps {
   items: ManageVideoItem[];
   onAdd: () => void;
   onChangeVideoId: (id: string, videoId: string) => void;
-  onCheckLevel: (id: string, level: LevelUnion, checked: boolean) => void;
+  onChangeLevel: (id: string, level: LevelUnion) => void;
   onCheckCategory: (
     id: string,
     category: CategoryUnion,
@@ -34,7 +34,7 @@ export function AddVideoTable({
   onRemove,
   onChangeVideoId,
   onCheckCategory,
-  onCheckLevel,
+  onChangeLevel,
 }: AddVideoTableProps) {
   const showAddButton = items.length < MANAGE_VIDEO_ITEM_MAX_COUNT;
 
@@ -54,10 +54,8 @@ export function AddVideoTable({
         }
       />,
       <LevelDropdown
-        // levels={item.levels}
-        // onCheck={(checked, level) => onCheckLevel(item.id, level, checked)}
-        level={item.levels.at(0) ?? 'BEGINNER'}
-        onChange={(level) => onCheckLevel(item.id, level, true)}
+        level={item.level}
+        onChange={(level) => onChangeLevel(item.id, level)}
       />,
       items.length > MANAGE_VIDEO_ITEM_MIN_COUNT && (
         <button

--- a/src/components/admin/category-dropdown/category-dropdown.tsx
+++ b/src/components/admin/category-dropdown/category-dropdown.tsx
@@ -1,4 +1,4 @@
-import { CategoryUnion } from '@/apis/models/video';
+import { Category } from '@/apis/models/video';
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -10,8 +10,8 @@ import {
 import { categoryItems } from '@/constants/type-label-map';
 
 interface CategoryDropdownProps {
-  categories: CategoryUnion[];
-  onCheck: (checked: boolean, category: CategoryUnion) => void;
+  categories: Category[];
+  onCheck: (checked: boolean, category: Category) => void;
 }
 
 export function CategoryDropdown({

--- a/src/components/admin/category-dropdown/category-dropdown.tsx
+++ b/src/components/admin/category-dropdown/category-dropdown.tsx
@@ -1,42 +1,47 @@
 import { CategoryUnion } from '@/apis/models/video';
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { categoryItems } from '@/constants/type-label-map';
 
 interface CategoryDropdownProps {
-  category: CategoryUnion;
-  onChange: (category: CategoryUnion) => void;
+  categories: CategoryUnion[];
+  onCheck: (checked: boolean, category: CategoryUnion) => void;
 }
 
 export function CategoryDropdown({
-  category,
-  onChange,
+  categories,
+  onCheck,
 }: CategoryDropdownProps) {
+  const label = categories.reduce((result, category, index) => {
+    const categoryLabel = categoryItems.get(category) ?? '';
+    if (index === 0) return categoryLabel;
+    if (!categoryLabel) return result;
+    return `${result}, ${categoryLabel}`;
+  }, '');
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="w-full text-left">
-        {categoryItems.get(category)}
+        {label}
       </DropdownMenuTrigger>
       <DropdownMenuContent>
         <DropdownMenuLabel>카테고리</DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuRadioGroup
-          value={category}
-          onValueChange={(value) => onChange(value as CategoryUnion)}
-        >
-          {Array.from(categoryItems).map(([key, label]) => (
-            <DropdownMenuRadioItem key={key} value={key}>
-              {label}
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
+        {Array.from(categoryItems).map(([key, label]) => (
+          <DropdownMenuCheckboxItem
+            key={key}
+            checked={categories.includes(key)}
+            onCheckedChange={(checked) => onCheck(checked, key)}
+          >
+            {label}
+          </DropdownMenuCheckboxItem>
+        ))}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/admin/level-dropdown/level-dropdown.tsx
+++ b/src/components/admin/level-dropdown/level-dropdown.tsx
@@ -11,22 +11,14 @@ import {
 import { levelItems } from '@/constants/type-label-map';
 
 interface LevelDropdownProps {
-  // levels: LevelUnion[];
-  // onCheck: (checked: boolean, level: LevelUnion) => void;
   level: LevelUnion;
   onChange: (level: LevelUnion) => void;
 }
 
 export function LevelDropdown({ level, onChange }: LevelDropdownProps) {
-  // const label = levels.reduce((result, level, index) => {
-  //   if (index === 0) return levelItems.get(level) ?? '';
-  //   return `${result}, ${levelItems.get(level)}`;
-  // }, '');
-
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className="line-clamp-1 w-full text-left">
-        {/* {label} */}
         {levelItems.get(level)}
       </DropdownMenuTrigger>
       <DropdownMenuContent>
@@ -42,15 +34,6 @@ export function LevelDropdown({ level, onChange }: LevelDropdownProps) {
             </DropdownMenuRadioItem>
           ))}
         </DropdownMenuRadioGroup>
-        {/* {Array.from(levelItems).map(([key, label]) => (
-          <DropdownMenuCheckboxItem
-            key={key}
-            checked={levels.includes(key)}
-            onCheckedChange={(checked) => onCheck(checked, key)}
-          >
-            {label}
-          </DropdownMenuCheckboxItem>
-        ))} */}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/src/components/admin/level-dropdown/level-dropdown.tsx
+++ b/src/components/admin/level-dropdown/level-dropdown.tsx
@@ -1,4 +1,4 @@
-import { LevelUnion } from '@/apis/models/video';
+import { Level } from '@/apis/models/video';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -11,8 +11,8 @@ import {
 import { levelItems } from '@/constants/type-label-map';
 
 interface LevelDropdownProps {
-  level: LevelUnion;
-  onChange: (level: LevelUnion) => void;
+  level: Level;
+  onChange: (level: Level) => void;
 }
 
 export function LevelDropdown({ level, onChange }: LevelDropdownProps) {
@@ -26,7 +26,7 @@ export function LevelDropdown({ level, onChange }: LevelDropdownProps) {
         <DropdownMenuSeparator />
         <DropdownMenuRadioGroup
           value={level}
-          onValueChange={(value) => onChange(value as LevelUnion)}
+          onValueChange={(value) => onChange(value as Level)}
         >
           {Array.from(levelItems).map(([key, label]) => (
             <DropdownMenuRadioItem key={key} value={key}>

--- a/src/constants/type-label-map.ts
+++ b/src/constants/type-label-map.ts
@@ -1,6 +1,6 @@
-import { CategoryUnion, LevelUnion } from '@/apis/models/video';
+import { Category, Level } from '@/apis/models/video';
 
-export const categoryItems = new Map<CategoryUnion, string>([
+export const categoryItems = new Map<Category, string>([
   ['FE', '프론트엔드'],
   ['BE', '백엔드'],
   ['AI', 'AI'],
@@ -8,7 +8,7 @@ export const categoryItems = new Map<CategoryUnion, string>([
   ['ETC', '기타'],
 ]);
 
-export const levelItems = new Map<LevelUnion, string>([
+export const levelItems = new Map<Level, string>([
   ['BEGINNER', '입문'],
   ['LOW', '초급'],
   ['MIDDLE', '중급 이상'],

--- a/src/containers/pages/admin/video/containers/add-video-dialog-content-container/add-video-dialog-content.container.tsx
+++ b/src/containers/pages/admin/video/containers/add-video-dialog-content-container/add-video-dialog-content.container.tsx
@@ -60,7 +60,7 @@ export function AddVideoDialogContentContainer({
         return {
           videoId: item.videoId,
           categories: item.categories,
-          level: item.levels.at(0) ?? 'BEGINNER',
+          level: item.level,
         };
       });
     if (videos.length > 0) {
@@ -87,8 +87,8 @@ export function AddVideoDialogContentContainer({
             payload: { id, category, checked },
           })
         }
-        onCheckLevel={(id, level, checked) =>
-          dispatch({ type: 'updateLevel', payload: { id, level, checked } })
+        onChangeLevel={(id, level) =>
+          dispatch({ type: 'updateLevel', payload: { id, level } })
         }
       />
 

--- a/src/containers/pages/admin/video/containers/add-video-dialog-content-container/add-video-dialog-content.container.tsx
+++ b/src/containers/pages/admin/video/containers/add-video-dialog-content-container/add-video-dialog-content.container.tsx
@@ -59,7 +59,7 @@ export function AddVideoDialogContentContainer({
       .map<AddVideoForAdminRequestParams['videos'][number]>((item) => {
         return {
           videoId: item.videoId,
-          category: item.category,
+          categories: item.categories,
           level: item.levels.at(0) ?? 'BEGINNER',
         };
       });
@@ -81,8 +81,11 @@ export function AddVideoDialogContentContainer({
         onChangeVideoId={(id, videoId) =>
           dispatch({ type: 'updateVideoId', payload: { id, videoId } })
         }
-        onSelectCategory={(id, category) =>
-          dispatch({ type: 'updateCategory', payload: { id, category } })
+        onCheckCategory={(id, category, checked) =>
+          dispatch({
+            type: 'updateCategory',
+            payload: { id, category, checked },
+          })
         }
         onCheckLevel={(id, level, checked) =>
           dispatch({ type: 'updateLevel', payload: { id, level, checked } })

--- a/src/containers/pages/admin/video/containers/add-video-dialog-content-container/reducers/manage-video.reducer.ts
+++ b/src/containers/pages/admin/video/containers/add-video-dialog-content-container/reducers/manage-video.reducer.ts
@@ -9,14 +9,18 @@ export const MANAGE_VIDEO_ITEM_MAX_COUNT = 10;
 export interface ManageVideoItem {
   id: string;
   videoId: string;
-  category: CategoryUnion;
+  categories: CategoryUnion[];
+  // todo 단일 선택으로 변경
   levels: LevelUnion[];
 }
 
 type ManageVideoAction =
   | { type: 'addItem' }
   | { type: 'updateVideoId'; payload: { id: string; videoId: string } }
-  | { type: 'updateCategory'; payload: { id: string; category: CategoryUnion } }
+  | {
+      type: 'updateCategory';
+      payload: { id: string; category: CategoryUnion; checked: boolean };
+    }
   | {
       type: 'updateLevel';
       payload: { id: string; level: LevelUnion; checked: boolean };
@@ -36,7 +40,7 @@ export const manageVideoReducer: Reducer<
         draft.push({
           id: uniqueId(),
           videoId: '',
-          category: 'FE',
+          categories: ['FE'],
           levels: ['BEGINNER'],
         });
       });
@@ -53,7 +57,13 @@ export const manageVideoReducer: Reducer<
       return produce(prevState, (draft) => {
         const index = draft.findIndex((item) => item.id === action.payload.id);
         if (index !== -1) {
-          draft[index].category = action.payload.category;
+          if (action.payload.checked) {
+            draft[index].categories.push(action.payload.category);
+          } else {
+            draft[index].categories = draft[index].categories.filter(
+              (item) => item !== action.payload.category,
+            );
+          }
         }
       });
     case 'updateLevel':

--- a/src/containers/pages/admin/video/containers/add-video-dialog-content-container/reducers/manage-video.reducer.ts
+++ b/src/containers/pages/admin/video/containers/add-video-dialog-content-container/reducers/manage-video.reducer.ts
@@ -1,7 +1,7 @@
 import { produce } from 'immer';
 import { uniqueId } from 'lodash';
 import { Reducer } from 'react';
-import { CategoryUnion, LevelUnion } from '@/apis/models/video';
+import { Category, Level } from '@/apis/models/video';
 
 export const MANAGE_VIDEO_ITEM_MIN_COUNT = 1;
 export const MANAGE_VIDEO_ITEM_MAX_COUNT = 10;
@@ -9,8 +9,8 @@ export const MANAGE_VIDEO_ITEM_MAX_COUNT = 10;
 export interface ManageVideoItem {
   id: string;
   videoId: string;
-  categories: CategoryUnion[];
-  level: LevelUnion;
+  categories: Category[];
+  level: Level;
 }
 
 type ManageVideoAction =
@@ -18,9 +18,9 @@ type ManageVideoAction =
   | { type: 'updateVideoId'; payload: { id: string; videoId: string } }
   | {
       type: 'updateCategory';
-      payload: { id: string; category: CategoryUnion; checked: boolean };
+      payload: { id: string; category: Category; checked: boolean };
     }
-  | { type: 'updateLevel'; payload: { id: string; level: LevelUnion } }
+  | { type: 'updateLevel'; payload: { id: string; level: Level } }
   | { type: 'removeItem'; id: string };
 
 export const manageVideoReducer: Reducer<

--- a/src/containers/pages/admin/video/containers/add-video-dialog-content-container/reducers/manage-video.reducer.ts
+++ b/src/containers/pages/admin/video/containers/add-video-dialog-content-container/reducers/manage-video.reducer.ts
@@ -10,8 +10,7 @@ export interface ManageVideoItem {
   id: string;
   videoId: string;
   categories: CategoryUnion[];
-  // todo 단일 선택으로 변경
-  levels: LevelUnion[];
+  level: LevelUnion;
 }
 
 type ManageVideoAction =
@@ -21,10 +20,7 @@ type ManageVideoAction =
       type: 'updateCategory';
       payload: { id: string; category: CategoryUnion; checked: boolean };
     }
-  | {
-      type: 'updateLevel';
-      payload: { id: string; level: LevelUnion; checked: boolean };
-    }
+  | { type: 'updateLevel'; payload: { id: string; level: LevelUnion } }
   | { type: 'removeItem'; id: string };
 
 export const manageVideoReducer: Reducer<
@@ -41,7 +37,7 @@ export const manageVideoReducer: Reducer<
           id: uniqueId(),
           videoId: '',
           categories: ['FE'],
-          levels: ['BEGINNER'],
+          level: 'BEGINNER',
         });
       });
     }
@@ -68,20 +64,9 @@ export const manageVideoReducer: Reducer<
       });
     case 'updateLevel':
       return produce(prevState, (draft) => {
-        // const index = draft.findIndex((item) => item.id === action.payload.id);
-        // if (index !== -1) {
-        //   if (action.payload.checked) {
-        //     draft[index].levels.push(action.payload.level);
-        //   } else {
-        //     draft[index].levels = draft[index].levels.filter(
-        //       (item) => item !== action.payload.level,
-        //     );
-        //   }
-        // }
-        // todo 단일 선택 임시 설정
         const index = draft.findIndex((item) => item.id === action.payload.id);
         if (index !== -1) {
-          draft[index].levels = [action.payload.level];
+          draft[index].level = action.payload.level;
         }
       });
     case 'removeItem':

--- a/src/containers/pages/admin/video/containers/add-video-dialog-content-container/utils/manage-video.util.ts
+++ b/src/containers/pages/admin/video/containers/add-video-dialog-content-container/utils/manage-video.util.ts
@@ -6,6 +6,6 @@ export const getInitialVideos = (count: number = 1): ManageVideoItem[] => {
     id: uniqueId(),
     videoId: '',
     categories: ['FE'],
-    levels: ['BEGINNER'],
+    level: 'BEGINNER',
   }));
 };

--- a/src/containers/pages/admin/video/containers/add-video-dialog-content-container/utils/manage-video.util.ts
+++ b/src/containers/pages/admin/video/containers/add-video-dialog-content-container/utils/manage-video.util.ts
@@ -5,7 +5,7 @@ export const getInitialVideos = (count: number = 1): ManageVideoItem[] => {
   return Array.from({ length: count }, () => ({
     id: uniqueId(),
     videoId: '',
-    category: 'FE',
+    categories: ['FE'],
     levels: ['BEGINNER'],
   }));
 };

--- a/src/containers/pages/admin/video/hooks/use-video-table.tsx
+++ b/src/containers/pages/admin/video/hooks/use-video-table.tsx
@@ -3,7 +3,7 @@ import {
   updateVideoInfoByIdForAdmin,
 } from '@/apis/admin';
 import { UpdateVideoInfoByIdForAdminRequestParams } from '@/apis/models/admin';
-import { CategoryUnion, GetVideoResponse } from '@/apis/models/video';
+import { Category, GetVideoResponse } from '@/apis/models/video';
 import { CategoryDropdown } from '@/components/admin/category-dropdown';
 import { TableRowDef } from '@/components/admin/data-table/types/data-table.type';
 import { LevelDropdown } from '@/components/admin/level-dropdown';
@@ -69,7 +69,7 @@ export const useVideoTable = ({ videos }: UseVideoTableProps) => {
 
   const handleCheckCategory =
     (video: GetVideoResponse) =>
-    (checked: boolean, checkedCategory: CategoryUnion) => {
+    (checked: boolean, checkedCategory: Category) => {
       handleUpdate(video.id, {
         categories: checked
           ? [...video.categories, checkedCategory]

--- a/src/containers/pages/admin/video/hooks/use-video-table.tsx
+++ b/src/containers/pages/admin/video/hooks/use-video-table.tsx
@@ -3,7 +3,7 @@ import {
   updateVideoInfoByIdForAdmin,
 } from '@/apis/admin';
 import { UpdateVideoInfoByIdForAdminRequestParams } from '@/apis/models/admin';
-import { GetVideoResponse } from '@/apis/models/video';
+import { CategoryUnion, GetVideoResponse } from '@/apis/models/video';
 import { CategoryDropdown } from '@/components/admin/category-dropdown';
 import { TableRowDef } from '@/components/admin/data-table/types/data-table.type';
 import { LevelDropdown } from '@/components/admin/level-dropdown';
@@ -67,6 +67,16 @@ export const useVideoTable = ({ videos }: UseVideoTableProps) => {
     updateMutation.mutate({ accessToken, videoId: id, params });
   };
 
+  const handleCheckCategory =
+    (video: GetVideoResponse) =>
+    (checked: boolean, checkedCategory: CategoryUnion) => {
+      handleUpdate(video.id, {
+        categories: checked
+          ? [...video.categories, checkedCategory]
+          : video.categories.filter((category) => category !== checkedCategory),
+      });
+    };
+
   const rows: TableRowDef[] =
     videos?.map((video) => ({
       key: video.id,
@@ -86,8 +96,8 @@ export const useVideoTable = ({ videos }: UseVideoTableProps) => {
         </div>,
         <div key="category" className="line-clamp-1 w-[80px]">
           <CategoryDropdown
-            category={video.category}
-            onChange={(category) => handleUpdate(video.id, { category })}
+            categories={video.categories}
+            onCheck={handleCheckCategory(video)}
           />
         </div>,
         <div key="level" className="line-clamp-1 w-[80px]">

--- a/src/containers/pages/explore/constants/filter.constant.ts
+++ b/src/containers/pages/explore/constants/filter.constant.ts
@@ -1,13 +1,7 @@
-import { categoryItems, levelItems } from '@/constants/type-label-map';
-import { Category } from '@/apis/models/video';
+import { levelItems } from '@/constants/type-label-map';
 import { FilterLevel } from '../models';
 
 export const levelFilterItems = new Map<FilterLevel, string>([
   ['all', '전체'],
   ...Array.from(levelItems),
-]);
-
-export const categoryFilterItems = new Map<Category, string>([
-  // ['all', '전체'],
-  ...Array.from(categoryItems),
 ]);

--- a/src/containers/pages/explore/constants/filter.constant.ts
+++ b/src/containers/pages/explore/constants/filter.constant.ts
@@ -1,7 +1,8 @@
 import { categoryItems, levelItems } from '@/constants/type-label-map';
-import { Category, Level } from '../models';
+import { Category } from '@/apis/models/video';
+import { FilterLevel } from '../models';
 
-export const levelFilterItems = new Map<Level, string>([
+export const levelFilterItems = new Map<FilterLevel, string>([
   ['all', '전체'],
   ...Array.from(levelItems),
 ]);

--- a/src/containers/pages/explore/constants/filter.constant.ts
+++ b/src/containers/pages/explore/constants/filter.constant.ts
@@ -7,6 +7,6 @@ export const levelFilterItems = new Map<Level, string>([
 ]);
 
 export const categoryFilterItems = new Map<Category, string>([
-  ['all', '전체'],
+  // ['all', '전체'],
   ...Array.from(categoryItems),
 ]);

--- a/src/containers/pages/explore/explore.container.tsx
+++ b/src/containers/pages/explore/explore.container.tsx
@@ -24,7 +24,7 @@ export function ExploreContainer() {
 
   const [filter, updateFilter] = useReducer(updateSearchFilterReducer, {
     level: 'all',
-    category: 'all',
+    categories: [],
   });
 
   const handleUpdate = (action: UpdateSearchFilterAction) => {
@@ -34,7 +34,10 @@ export function ExploreContainer() {
 
   useDetectCategoryFromParam({
     onDetect: (category) => {
-      updateFilter({ type: 'category', payload: category });
+      updateFilter({
+        type: 'categories',
+        payload: { category, checked: true },
+      });
     },
   });
 
@@ -51,7 +54,7 @@ export function ExploreContainer() {
           page: currentPage,
           keyword: keywordFromParam || undefined,
           level: filter.level === 'all' ? undefined : filter.level,
-          category: filter.category === 'all' ? undefined : filter.category,
+          categories: filter.categories,
         });
       },
       staleTime: 60 * 1000,
@@ -110,12 +113,18 @@ export function ExploreContainer() {
                   return (
                     <label key={key} className="flex gap-[8px]">
                       <input
-                        type="radio"
+                        type="checkbox"
                         name="category"
                         value={key}
-                        checked={key === filter.category}
-                        onChange={() =>
-                          handleUpdate({ type: 'category', payload: key })
+                        checked={filter.categories.includes(key)}
+                        onChange={(e) =>
+                          handleUpdate({
+                            type: 'categories',
+                            payload: {
+                              category: key,
+                              checked: e.target.checked,
+                            },
+                          })
                         }
                       />
                       {label}

--- a/src/containers/pages/explore/explore.container.tsx
+++ b/src/containers/pages/explore/explore.container.tsx
@@ -8,7 +8,8 @@ import {
 } from '@/components/shared';
 import { VideoList } from '@/components/shared/video-list';
 import { usePagination } from '@/components/shared/pagination/hooks';
-import { categoryFilterItems, levelFilterItems } from './constants';
+import { categoryItems } from '@/constants/type-label-map';
+import { levelFilterItems } from './constants';
 import { useDetectCategoryFromParam, useGetVideos } from './hooks';
 import {
   UpdateSearchFilterAction,
@@ -109,7 +110,7 @@ export function ExploreContainer() {
             <fieldset>
               <legend className="text-md pb-[16px] font-bold">카테고리</legend>
               <div className="flex flex-col gap-[8px]">
-                {Array.from(categoryFilterItems).map(([key, label]) => {
+                {Array.from(categoryItems).map(([key, label]) => {
                   return (
                     <label key={key} className="flex gap-[8px]">
                       <input

--- a/src/containers/pages/explore/hooks/use-detect-category-from-param.ts
+++ b/src/containers/pages/explore/hooks/use-detect-category-from-param.ts
@@ -1,6 +1,6 @@
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
-import { Category } from '../models';
+import { Category } from '@/apis/models/video';
 import { isCategoryFilterItemKey } from '../utils/type-checker';
 
 export const INIT_CATEGORY_KEY = 'initCategory';

--- a/src/containers/pages/explore/models/filter.ts
+++ b/src/containers/pages/explore/models/filter.ts
@@ -1,4 +1,4 @@
 import { CategoryUnion, LevelUnion } from '@/apis/models/video';
 
 export type Level = 'all' | LevelUnion;
-export type Category = 'all' | CategoryUnion;
+export type Category = CategoryUnion;

--- a/src/containers/pages/explore/models/filter.ts
+++ b/src/containers/pages/explore/models/filter.ts
@@ -1,4 +1,3 @@
-import { CategoryUnion, LevelUnion } from '@/apis/models/video';
+import { Level } from '@/apis/models/video';
 
-export type Level = 'all' | LevelUnion;
-export type Category = CategoryUnion;
+export type FilterLevel = 'all' | Level;

--- a/src/containers/pages/explore/reducers/update-search-filter.reducer.ts
+++ b/src/containers/pages/explore/reducers/update-search-filter.reducer.ts
@@ -4,11 +4,11 @@ import { Category, Level } from '../models';
 
 export type UpdateSearchFilterAction =
   | { type: 'level'; payload: Level }
-  | { type: 'category'; payload: Category };
+  | { type: 'categories'; payload: { category: Category; checked: boolean } };
 
 type UpdateSearchFilterState = {
   level: Level;
-  category: Category;
+  categories: Category[];
 };
 
 export const updateSearchFilterReducer: Reducer<
@@ -20,9 +20,18 @@ export const updateSearchFilterReducer: Reducer<
       return produce(prevState, (draft) => {
         draft.level = action.payload;
       });
-    case 'category':
+    case 'categories':
       return produce(prevState, (draft) => {
-        draft.category = action.payload;
+        if (
+          action.payload.checked &&
+          !draft.categories.includes(action.payload.category)
+        ) {
+          draft.categories = [...draft.categories, action.payload.category];
+        } else if (!action.payload.checked) {
+          draft.categories = draft.categories.filter(
+            (category) => category !== action.payload.category,
+          );
+        }
       });
     default:
       return prevState;

--- a/src/containers/pages/explore/reducers/update-search-filter.reducer.ts
+++ b/src/containers/pages/explore/reducers/update-search-filter.reducer.ts
@@ -1,13 +1,14 @@
 import { produce } from 'immer';
 import { Reducer } from 'react';
-import { Category, Level } from '../models';
+import { Category } from '@/apis/models/video';
+import { FilterLevel } from '../models';
 
 export type UpdateSearchFilterAction =
-  | { type: 'level'; payload: Level }
+  | { type: 'level'; payload: FilterLevel }
   | { type: 'categories'; payload: { category: Category; checked: boolean } };
 
 type UpdateSearchFilterState = {
-  level: Level;
+  level: FilterLevel;
   categories: Category[];
 };
 

--- a/src/containers/pages/explore/utils/type-checker.ts
+++ b/src/containers/pages/explore/utils/type-checker.ts
@@ -1,10 +1,10 @@
 import { Category } from '@/apis/models/video';
-import { categoryFilterItems } from '../constants';
+import { categoryItems } from '@/constants/type-label-map';
 
 export function isCategoryFilterItemKey(value: unknown): value is Category {
   if (typeof value !== 'string') {
     return false;
   }
-  const categoryKeys = Array.from(categoryFilterItems.keys());
+  const categoryKeys = Array.from(categoryItems.keys());
   return categoryKeys.includes(value as Category);
 }

--- a/src/containers/pages/explore/utils/type-checker.ts
+++ b/src/containers/pages/explore/utils/type-checker.ts
@@ -1,5 +1,5 @@
+import { Category } from '@/apis/models/video';
 import { categoryFilterItems } from '../constants';
-import { Category } from '../models';
 
 export function isCategoryFilterItemKey(value: unknown): value is Category {
   if (typeof value !== 'string') {


### PR DESCRIPTION
- 관리자 페이지 LevelDropdown 컴포넌트에서 임시로 주석했던 다중 선택 코드 삭제
- CategoryDropdown 컴포넌트 카테고리 다중 선택할 수 있게 수정
- 탐색 페이지 필터 카테고리 다중 선택되도록 수정
- 관련 스키마 변경사항 반영