### PR TITLE
[디자인] UI 이슈 수정

### DIFF
--- a/public/close.svg
+++ b/public/close.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-linecap="round"
-    stroke-linejoin="round" stroke-width="2">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" fill="none" stroke="currentColor"
+    stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
     <line x1="7" x2="25" y1="7" y2="25" />
     <line x1="7" x2="25" y1="25" y2="7" />
 </svg>

--- a/src/components/main-page/hero-copy.tsx
+++ b/src/components/main-page/hero-copy.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image';
 
 export function HeroCopy() {
   return (
-    <h1 className="text-5xl font-bold leading-snug text-gray-800 max-sm:text-4xl">
+    <h1 className="text-5xl font-bold leading-snug text-gray-800 max-md:text-4xl max-sm:text-3xl">
       <span className="flex gap-5 max-sm:gap-3">
         <div className="relative">
           <Image
@@ -10,7 +10,7 @@ export function HeroCopy() {
             src="/youtube-logo.webp"
             width={1143 / 14}
             height={255 / 14}
-            alt="youtube logo"
+            alt="YouTube"
           />
           YouTube
         </div>

--- a/src/components/responsive-header/mobile-header-contents.tsx
+++ b/src/components/responsive-header/mobile-header-contents.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { useOpenState } from '@/hooks';
+import { useEffect } from 'react';
+import { useOpenState, usePreventScroll, useScreenSize } from '@/hooks';
 import { Button, PopoverBackdrop } from '../shared';
 import { Logo } from './logo';
 
@@ -13,6 +14,19 @@ const MENU_ITEM_STYLE =
 
 export function MobileHeader({ isLoggedIn = false }: MobileHeaderProps) {
   const { isOpen, handleState } = useOpenState();
+
+  const { screenSize } = useScreenSize();
+
+  useEffect(() => {
+    if (screenSize === 'sm' || screenSize === 'md') {
+      return;
+    }
+    if (isOpen) {
+      handleState.close();
+    }
+  }, [screenSize, isOpen, handleState]);
+
+  usePreventScroll({ scrollable: !isOpen });
 
   return (
     <>
@@ -43,7 +57,7 @@ export function MobileHeader({ isLoggedIn = false }: MobileHeaderProps) {
 
       {isOpen && (
         <PopoverBackdrop
-          className="absolute left-0 top-[65px] h-screen bg-black/70"
+          className="top-[65px] h-screen bg-black/70"
           onClick={handleState.close}
         >
           <div className="flex w-full flex-col gap-3 bg-white px-5 pb-7 text-gray-800 shadow-md">

--- a/src/components/responsive-header/mobile-header-contents.tsx
+++ b/src/components/responsive-header/mobile-header-contents.tsx
@@ -1,7 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect } from 'react';
-import { useOpenState, usePreventScroll, useScreenSize } from '@/hooks';
+import {
+  ScreenSize,
+  useOpenState,
+  usePreventScroll,
+  useScreenSize,
+} from '@/hooks';
 import { Button, PopoverBackdrop } from '../shared';
 import { Logo } from './logo';
 
@@ -18,7 +23,7 @@ export function MobileHeader({ isLoggedIn = false }: MobileHeaderProps) {
   const { screenSize } = useScreenSize();
 
   useEffect(() => {
-    if (screenSize === 'sm' || screenSize === 'md') {
+    if (screenSize <= ScreenSize.medium) {
       return;
     }
     if (isOpen) {

--- a/src/components/shared/layout-with-header/layout-with-header.tsx
+++ b/src/components/shared/layout-with-header/layout-with-header.tsx
@@ -20,7 +20,7 @@ export function LayoutWithHeader({
         <title>{title}</title>
       </Head>
 
-      <div className="relative flex h-full flex-col">
+      <div className="flex min-h-screen flex-col">
         <ResponsiveHeader isLoggedIn={isLoggedIn} />
         {children}
         <Footer />

--- a/src/components/shared/popover-backdrop/popover-backdrop.tsx
+++ b/src/components/shared/popover-backdrop/popover-backdrop.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useEffect } from 'react';
+import { PropsWithChildren, useEffect, useRef, MouseEvent } from 'react';
 import { cn } from '@/utils/styling';
 
 interface PopoverBackdropProps {
@@ -11,6 +11,8 @@ export function PopoverBackdrop({
   className,
   onClick,
 }: PropsWithChildren<PopoverBackdropProps>) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -21,10 +23,17 @@ export function PopoverBackdrop({
     return () => document.removeEventListener('keydown', handleKeyDown);
   });
 
+  const handleClick = (e: MouseEvent) => {
+    if (ref.current && ref.current === e.target) {
+      onClick?.();
+    }
+  };
+
   return (
     <div
+      ref={ref}
       className={cn('absolute left-0 top-0 h-full w-full', className)}
-      onClick={onClick}
+      onClick={handleClick}
       role="presentation"
     >
       {children}

--- a/src/containers/pages/explore/explore.container.tsx
+++ b/src/containers/pages/explore/explore.container.tsx
@@ -34,7 +34,8 @@ export function ExploreContainer() {
     categories: [],
   });
 
-  const { isOpenFilterDrawer, handleFilterDrawer } = useOpenFilterDrawer();
+  const { isOpenFilterDrawer, handleFilterDrawer, isResponsiveSize } =
+    useOpenFilterDrawer();
 
   useDetectCategoryFromParam({
     onDetect: (category) => {
@@ -88,23 +89,25 @@ export function ExploreContainer() {
 
           <div className="flex w-full flex-col gap-[24px] md:flex-row">
             {/* 필터 */}
-            <aside className="w-1/4 min-w-[150px] max-md:hidden">
-              <div className="separate-line pb-6 text-xl">필터</div>
-              <ExploreFilter
-                className="py-5"
-                level={filter.level}
-                categories={filter.categories}
-                onLevelChange={(level) => {
-                  handleUpdate({ type: 'level', payload: level });
-                }}
-                onCategoryChange={(category, checked) => {
-                  handleUpdate({
-                    type: 'categories',
-                    payload: { category, checked },
-                  });
-                }}
-              />
-            </aside>
+            {!isResponsiveSize && (
+              <aside className="w-1/4 min-w-[150px]">
+                <div className="separate-line pb-6 text-xl">필터</div>
+                <ExploreFilter
+                  className="py-5"
+                  level={filter.level}
+                  categories={filter.categories}
+                  onLevelChange={(level) => {
+                    handleUpdate({ type: 'level', payload: level });
+                  }}
+                  onCategoryChange={(category, checked) => {
+                    handleUpdate({
+                      type: 'categories',
+                      payload: { category, checked },
+                    });
+                  }}
+                />
+              </aside>
+            )}
 
             <div className="w-full">
               <div className="flex justify-between gap-1 pb-6">

--- a/src/containers/pages/explore/hooks/use-open-filter-drawer.ts
+++ b/src/containers/pages/explore/hooks/use-open-filter-drawer.ts
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useOpenState, useScreenSize } from '@/hooks';
+import { useEffect, useMemo } from 'react';
+import { ScreenSize, useOpenState, useScreenSize } from '@/hooks';
 
 export const useOpenFilterDrawer = () => {
   const { isOpen: isOpenFilterDrawer, handleState: handleFilterDrawer } =
@@ -7,15 +7,23 @@ export const useOpenFilterDrawer = () => {
 
   const { screenSize } = useScreenSize();
 
+  const isResponsiveSize = useMemo(() => {
+    return screenSize <= ScreenSize.medium;
+  }, [screenSize]);
+
   useEffect(() => {
     // filter drawer 열린 상태에서 뷰포트 너비 커지면 닫힘
-    if (screenSize === 'sm' || screenSize === 'md') {
+    if (isResponsiveSize) {
       return;
     }
     if (isOpenFilterDrawer) {
       handleFilterDrawer.close();
     }
-  }, [handleFilterDrawer, isOpenFilterDrawer, screenSize]);
+  }, [handleFilterDrawer, isOpenFilterDrawer, isResponsiveSize]);
 
-  return { isOpenFilterDrawer, handleFilterDrawer };
+  return {
+    isOpenFilterDrawer,
+    handleFilterDrawer,
+    isResponsiveSize,
+  };
 };

--- a/src/containers/pages/main/main.container.tsx
+++ b/src/containers/pages/main/main.container.tsx
@@ -13,10 +13,10 @@ export function MainContainer() {
   const recommendedVideos = useRecommendedVideos();
 
   return (
-    <main className="mb-[100px] w-full">
+    <main className="mb-24 w-full">
       {/* hero */}
       <section className="bg-primary/25">
-        <div className="layout flex flex-col gap-[48px] py-[100px]">
+        <div className="layout flex flex-col gap-12 py-24 max-sm:py-20">
           <HeroCopy />
           <SearchInput
             className="basis-x-[600px]"
@@ -29,9 +29,9 @@ export function MainContainer() {
       </section>
 
       {/* category */}
-      <section className="layout pt-[48px]">
+      <section className="layout pt-12">
         <SectionTitle title="카테고리 🗂️" />
-        <ul className="flex flex-wrap gap-[16px]">
+        <ul className="flex flex-wrap gap-4">
           {Array.from(categoryItems).map(([key, label]) => (
             <Category
               key={key}
@@ -46,7 +46,7 @@ export function MainContainer() {
       {Array.from(recommendedSections).map(({ title, videoIds }) => {
         const videos: VideoItem[] = getVideoItems(videoIds, recommendedVideos);
         return (
-          <section key={encodeURI(title)} className="layout pt-[48px]">
+          <section key={encodeURI(title)} className="layout pt-12">
             <SectionTitle title={title} />
             <VideoList items={videos} />
           </section>

--- a/src/containers/pages/signin/signin.container.tsx
+++ b/src/containers/pages/signin/signin.container.tsx
@@ -16,7 +16,7 @@ export function SignInContainer() {
   });
 
   return (
-    <main className="flex h-full flex-col items-center justify-center">
+    <main className="flex h-screen flex-col items-center justify-center">
       <Image src="/flag.svg" width={100} height={100} alt="logo" />
       <Link className="mb-9 text-5xl text-primary" href="/">
         Coply

--- a/src/hooks/use-prevent-scroll.ts
+++ b/src/hooks/use-prevent-scroll.ts
@@ -1,10 +1,25 @@
+import { all } from 'node_modules/axios/index.cjs';
 import { useEffect } from 'react';
 
-export const usePreventScroll = () => {
+interface UsePreventScrollProps {
+  scrollable?: boolean;
+}
+
+export const usePreventScroll = (
+  { scrollable = false }: UsePreventScrollProps = { scrollable: false },
+) => {
+  const allowScroll = (isAllow: boolean) => {
+    if (!isAllow) {
+      document.body.style.overflow = 'hidden';
+      return;
+    }
+    document.body.style.overflow = 'unset';
+  };
+
   useEffect(() => {
-    document.body.style.overflow = 'hidden';
+    allowScroll(scrollable);
     return () => {
-      document.body.style.overflow = 'unset';
+      allowScroll(true);
     };
-  }, []);
+  }, [scrollable]);
 };

--- a/src/hooks/use-prevent-scroll.ts
+++ b/src/hooks/use-prevent-scroll.ts
@@ -1,4 +1,3 @@
-import { all } from 'node_modules/axios/index.cjs';
 import { useEffect } from 'react';
 
 interface UsePreventScrollProps {

--- a/src/hooks/use-screen-size.ts
+++ b/src/hooks/use-screen-size.ts
@@ -2,6 +2,14 @@ import { useMemo } from 'react';
 import { getScreenSize } from '@/utils/screen-size.util';
 import { useMediaQuery } from './use-media-query';
 
+export enum ScreenSize {
+  small = 1,
+  medium = 2,
+  large = 3,
+  extraLarge = 4,
+  doubleExtraLarge = 5,
+}
+
 const { sm, md, lg, xl } = getScreenSize();
 
 export const useScreenSize = () => {
@@ -11,23 +19,23 @@ export const useScreenSize = () => {
   const isMedium = useMediaQuery(`(${sm} < width <= ${md})`);
   const isSmall = useMediaQuery(`(width <= ${sm})`);
 
-  const screenSize = useMemo((): '2xl' | 'xl' | 'lg' | 'md' | 'sm' => {
+  const screenSize = useMemo((): ScreenSize => {
     if (is2ExtraLarge) {
-      return '2xl';
+      return ScreenSize.doubleExtraLarge;
     }
     if (isExtraLarge) {
-      return 'xl';
+      return ScreenSize.extraLarge;
     }
     if (isLarge) {
-      return 'lg';
+      return ScreenSize.large;
     }
     if (isMedium) {
-      return 'md';
+      return ScreenSize.medium;
     }
     if (isSmall) {
-      return 'sm';
+      return ScreenSize.small;
     }
-    return '2xl';
+    return ScreenSize.doubleExtraLarge;
   }, [is2ExtraLarge, isExtraLarge, isLarge, isMedium, isSmall]);
 
   return {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,10 +7,10 @@ import {
   QueryClientProvider,
 } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { noto_sans_kr } from '@/styles/fonts';
 
 import '@/styles/globals.css';
 import '@/styles/reset.css';
-
 import type { AppProps } from 'next/app';
 
 export type NextPageWithLayout<P = object, IP = P> = NextPage<P, IP> & {
@@ -44,8 +44,10 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 
       <QueryClientProvider client={queryClient}>
         <HydrationBoundary state={pageProps.dehydratedState}>
-          {getLayout(<Component {...pageProps} />)}
-          <div id="portal" />
+          <main className={noto_sans_kr.className}>
+            {getLayout(<Component {...pageProps} />)}
+            <div id="portal" />
+          </main>
         </HydrationBoundary>
         <ReactQueryDevtools />
       </QueryClientProvider>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -25,10 +25,3 @@ html {
   font-family: var(--font-noto-sans-kr);
   @apply text-base;
 }
-
-html,
-body,
-body > div:first-child,
-div#__next {
-  min-height: 100%;
-}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -22,6 +22,5 @@
 }
 
 html {
-  font-family: var(--font-noto-sans-kr);
   @apply text-base;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -30,5 +30,5 @@ html,
 body,
 body > div:first-child,
 div#__next {
-  height: 100%;
+  min-height: 100%;
 }


### PR DESCRIPTION
## 수정한 이슈
- 메인 페이지에서 스크롤 했을 때 헤더 사라짐 -> 헤더 항상 고정 위치에 있도록 수정
- 로그인 페이지 여백 설정 안됨 -> 중앙에 ui 위치하도록 수정
- 모바일 헤더 메뉴 열었을 때 뒷부분 스크롤 됨 -> 스크롤 되지 않도록 수정
- 필터 drawer 에서 난이도 선택 시 간헐적으로 선택 해제됨 -> 선택 해제되는 경우 없도록 수정
- 재생 페이지 재생 정보 drawer 어딜 클릭해도 닫힘 -> backdrop 과 닫기 버튼 클릭했을 때만 닫히도록 수정
- 사파리에서 svg import 해와서 렌더링할 경우 닫기 버튼 표시되지 않음 -> 표시되도록 수정
- 폰트 적용 안됨 -> 적용되도록 수정

## 코드 변경 사항
- 전역 height 삭제
- 필터 난이도는 스크린 사이즈에 따라 한번만 렌더링하도록 수정